### PR TITLE
Add <itunes:subtitle> tag to rss items

### DIFF
--- a/spotifeed.rb
+++ b/spotifeed.rb
@@ -69,6 +69,7 @@ class Spotifeed < Sinatra::Base
           item.description = episode['description']
           item.date = Time.parse(episode['release_date'] || '01-01-2020').to_s
 
+          item.itunes_subtitle = episode['description']
           item.itunes_image = episode.dig('images', 0, 'url')
           item.itunes_duration = "%02d:%02d:%02d" % [duration_secs / 3600, duration_secs / 60 % 60, duration_secs % 60]
           item.itunes_explicit = episode['explicit']


### PR DESCRIPTION
First of all: THANKS SO MUCH FOR THIS! 🙏️

I've added a feed to Overcast and saw that I only have titles in the main list, but not more info about the episode. Did some search and found that [it and many other podcast clients](https://podnews.net/article/html-episode-notes-in-podcast-rss) use `<itunes:subtitle>` for this.

So this PR adds it.